### PR TITLE
Bug Fix for double press of an operation

### DIFF
--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -95,11 +95,14 @@ export default function calculate(obj, buttonName) {
 
   // User pressed an operation button and there is an existing operation
   if (obj.operation) {
-    return {
-      total: operate(obj.total, obj.next, obj.operation),
-      next: null,
-      operation: buttonName,
-    };
+    // change added to fix the bug when a same operation is pressed twice and the state is something like : 7 + +, it results in an error since, big.js gets num2 = null
+    if(obj.next) {
+      return {
+        total: operate(obj.total, obj.next, obj.operation),
+        next: null,
+        operation: buttonName,
+      };
+    }  
   }
 
   // no operation yet, but the user typed one


### PR DESCRIPTION
For example; 
If user enters 7 + +. it results into an error on screen.  

Reason : it gets directed to operate.js where num2 is null only, so we need to put a check on whether to direct it or not.